### PR TITLE
fix: support the changed field names

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,8 @@ async function reassertLastResult(assertViewResults, {maxDiffSize, dry}, test) {
     }
 
     try {
-        const {stateName, refImagePath, currentImagePath} = lastResult;
-        const isEqual = await util.compareImages({refImagePath, currentImagePath, maxDiffSize});
+        const {stateName, refImg, currImg} = lastResult;
+        const isEqual = await util.compareImages({refImgPath: refImg.path, currImgPath: currImg.path, maxDiffSize});
 
         const testTitle = test.fullTitle();
         const browserId = test.browserId;
@@ -51,7 +51,7 @@ async function reassertLastResult(assertViewResults, {maxDiffSize, dry}, test) {
         debug(`'${testTitle} :: ${stateName} :: ${browserId}' images are the same!`);
 
         if (!dry) {
-            assertViewResults[assertViewResults.length - 1] = {stateName, refImagePath};
+            assertViewResults[assertViewResults.length - 1] = {stateName, refImg};
         }
     } catch (e) {
         debug(e);

--- a/test/index.js
+++ b/test/index.js
@@ -125,7 +125,7 @@ describe('hermione-reassert-view', () => {
 
         it('should not compare images on success', async () => {
             const assertViewResults = [
-                {stateName: 'foo', refImagePath: '/bar/baz'}
+                {stateName: 'foo'}
             ];
             const browser = init_({assertViewResults});
 
@@ -147,7 +147,7 @@ describe('hermione-reassert-view', () => {
 
         it('should compare images on diff', async () => {
             const assertViewResults = [
-                {name: 'ImageDiffError'}
+                {name: 'ImageDiffError', refImg: {}, currImg: {}}
             ];
             const maxDiffSize = {
                 width: 100500, height: 500100
@@ -188,8 +188,8 @@ describe('hermione-reassert-view', () => {
             const assertViewResults = [{
                 name: 'ImageDiffError',
                 stateName: 'foo',
-                refImagePath: '/bar/baz',
-                currentImagePath: '/qux'
+                refImg: {path: '/bar/baz'},
+                currImg: {path: '/qux'}
             }];
             const browser = init_({assertViewResults});
             util.compareImages.resolves(true);
@@ -198,7 +198,7 @@ describe('hermione-reassert-view', () => {
 
             assert.deepEqual(
                 browser.executionContext.hermioneCtx.assertViewResults.get(),
-                [{stateName: 'foo', refImagePath: '/bar/baz'}]
+                [{stateName: 'foo', refImg: {path: '/bar/baz'}}]
             );
         });
 

--- a/test/util.js
+++ b/test/util.js
@@ -27,7 +27,7 @@ describe('hermione-reassert-view/util', () => {
         };
 
         it('should compare images with antialiasing and without antialiasing', async () => {
-            await compareImages_({refImagePath: '/ref', currentImagePath: '/curr'});
+            await compareImages_({refImgPath: '/ref', currImgPath: '/curr'});
 
             assert.calledTwice(compareImages);
             assert.calledWith(compareImages, '/ref', '/curr', {ignore: 'antialiasing'});

--- a/util.js
+++ b/util.js
@@ -4,10 +4,10 @@ const compareImages = require('@gemini-testing/resemblejs/compareImages');
 const util = require('util');
 const debug = require('debug')('hermione-reassert-view');
 
-exports.compareImages = async function({refImagePath, currentImagePath, maxDiffSize}) {
+exports.compareImages = async function({refImgPath, currImgPath, maxDiffSize}) {
     const [results, resultsWithoutAntialiasing] = await Promise.all([
-        compareImages(refImagePath, currentImagePath, {ignore: 'less'}),
-        compareImages(refImagePath, currentImagePath, {ignore: 'antialiasing'})
+        compareImages(refImgPath, currImgPath, {ignore: 'less'}),
+        compareImages(refImgPath, currImgPath, {ignore: 'antialiasing'})
     ]);
 
     debug(`maxDiffSize: ${util.inspect(maxDiffSize)}`);


### PR DESCRIPTION
* "refImagePath" -> "refImg.path"
* "currentImagePath" -> "currImg.path"