### PR TITLE
fix: do not fail on empty assertView result

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = (hermione, opts) => {
 };
 
 async function reassertLastResult(assertViewResults, {maxDiffSize, dry}, test) {
-    const lastResult = assertViewResults[assertViewResults.length - 1];
+    const lastResult = assertViewResults[assertViewResults.length - 1] || {};
     if (lastResult.name !== 'ImageDiffError') {
         return;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -145,6 +145,14 @@ describe('hermione-reassert-view', () => {
             assert.notCalled(util.compareImages);
         });
 
+        it('should not compare images if there are no assertView results', async () => {
+            const browser = init_({assertViewResults: []});
+
+            await browser.assertView();
+
+            assert.notCalled(util.compareImages);
+        });
+
         it('should compare images on diff', async () => {
             const assertViewResults = [
                 {name: 'ImageDiffError'}


### PR DESCRIPTION
//cc @j0tunn 
it can be empty while using --update-refs option