### PR TITLE
Use hermione diffClusters instead of resemble diffBounds

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,13 @@ async function reassertLastResult(assertViewResults, {maxDiffSize, dry}, test) {
         return;
     }
 
+    if (!util.validateDiffSize(lastResult, maxDiffSize)) {
+        return;
+    }
+
     try {
         const {stateName, refImg, currImg} = lastResult;
-        const isEqual = await util.compareImages({refImgPath: refImg.path, currImgPath: currImg.path, maxDiffSize});
+        const isEqual = await util.compareImages(refImg.path, currImg.path);
 
         const testTitle = test.fullTitle();
         const browserId = test.browserId;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,24 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@gemini-testing/canvas-prebuilt": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/@gemini-testing/canvas-prebuilt/-/canvas-prebuilt-1.6.16.tgz",
-      "integrity": "sha512-08bN9txFQZT8cdrPRhODtf8aMhdLa9XQhroPJDo6HAIbrm0AbQXNcDQKO46teVi8Fj4C8yK0XcIZxG5kPaLj8A==",
-      "requires": {
-        "detect-libc": "^1.0.3",
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      }
-    },
-    "@gemini-testing/resemblejs": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@gemini-testing/resemblejs/-/resemblejs-2.11.4.tgz",
-      "integrity": "sha512-BK8/Pt2JvixOlpaaZJ8uD8+MewRjKEYJWYsKgU8squl5NGCwFHkBjP5XUutRx9ZfIhJGF8TITnbEixlvIr88WQ==",
-      "requires": {
-        "@gemini-testing/canvas-prebuilt": "^1.6.16"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
@@ -225,6 +207,34 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
+    },
+    "canvas": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.2.0.tgz",
+      "integrity": "sha512-4blMi2I2DuHh9UZNrmvU0hyY4dZJFOjNuqaZpI/66pKCyX1HPstvK+f2fIdc+NaF8b6wiuhvwXEFNkm7jIKYSA==",
+      "requires": {
+        "nan": "^2.11.1",
+        "node-pre-gyp": "^0.11.0"
+      },
+      "dependencies": {
+        "node-pre-gyp": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+          "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        }
+      }
     },
     "chai": {
       "version": "4.2.0",
@@ -1185,23 +1195,6 @@
         "text-encoding": "^0.6.4"
       }
     },
-    "node-pre-gyp": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
-      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
-      }
-    },
     "nopt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
@@ -1448,6 +1441,14 @@
       "requires": {
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
+      }
+    },
+    "resemblejs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resemblejs/-/resemblejs-3.1.0.tgz",
+      "integrity": "sha512-r/5FkGykUH2PSYfKX9Rzpb84wJcd6G/0z1iD32AsPZxNVjX3ndzsVU8UtvTaf2MnbuliL/S775KC8UTkHh/1yQ==",
+      "requires": {
+        "canvas": "2.2.0"
       }
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "sinon": "^6.0.1"
   },
   "dependencies": {
-    "@gemini-testing/resemblejs": "^2.11.4",
     "debug": "^4.1.0",
-    "gemini-configparser": "^1.0.0"
+    "gemini-configparser": "^1.0.0",
+    "resemblejs": "^3.1.0"
   }
 }

--- a/test/util.js
+++ b/test/util.js
@@ -9,7 +9,7 @@ describe('hermione-reassert-view/util', () => {
     beforeEach(() => {
         compareImages = sinon.stub().named('compareImages').resolves({});
         util = proxyquire('../util', {
-            '@gemini-testing/resemblejs/compareImages': compareImages
+            'resemblejs/compareImages': compareImages
         });
     });
 

--- a/util.js
+++ b/util.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const compareImages = require('@gemini-testing/resemblejs/compareImages');
+const compareImages = require('resemblejs/compareImages');
 const util = require('util');
 const debug = require('debug')('hermione-reassert-view');
 

--- a/util.js
+++ b/util.js
@@ -4,19 +4,20 @@ const compareImages = require('@gemini-testing/resemblejs/compareImages');
 const util = require('util');
 const debug = require('debug')('hermione-reassert-view');
 
-exports.compareImages = async function({refImgPath, currImgPath, maxDiffSize}) {
-    const [results, resultsWithoutAntialiasing] = await Promise.all([
-        compareImages(refImgPath, currImgPath, {ignore: 'less'}),
-        compareImages(refImgPath, currImgPath, {ignore: 'antialiasing'})
-    ]);
-
+exports.validateDiffSize = function({diffClusters}, maxDiffSize) {
+    debug(`diffClusters: ${util.inspect(diffClusters)}`);
     debug(`maxDiffSize: ${util.inspect(maxDiffSize)}`);
-    debug(`with Antialiasing: ${util.inspect(results)}`);
-    debug(`without Antialiasing: ${util.inspect(resultsWithoutAntialiasing)}`);
 
-    const {diffBounds} = results;
+    return diffClusters.every(({left, right, top, bottom}) => {
+        return right - left <= maxDiffSize.width
+            && bottom - top <= maxDiffSize.height;
+    });
+};
 
-    return resultsWithoutAntialiasing.rawMisMatchPercentage === 0
-        && diffBounds.right - diffBounds.left < maxDiffSize.width
-        && diffBounds.bottom - diffBounds.top < maxDiffSize.height;
+exports.compareImages = async function(refPath, currPath) {
+    const res = await compareImages(refPath, currPath, {ignore: 'antialiasing'});
+
+    debug(`compare results ignoring Antialiasing: ${util.inspect(res)}`);
+
+    return res.rawMisMatchPercentage === 0;
 };


### PR DESCRIPTION
- Use hermione diffClusters instead of resemble diffBounds to check diff bounds
- Migrate to resemblejs upstream