### PR TITLE
feat: migrate to webdriverio@7

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = (hermione, opts) => {
             return;
         }
         async function reassertView(baseAssertViewFn, ...args) {
-            await baseAssertViewFn.apply(this, args);
+            await baseAssertViewFn(...args);
 
             const assertViewResults = browser.executionContext.hermioneCtx.assertViewResults.get();
 
@@ -27,6 +27,7 @@ module.exports = (hermione, opts) => {
         }
 
         browser.overwriteCommand('assertView', reassertView);
+        browser.overwriteCommand('assertView', reassertView, true);
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -18,15 +18,15 @@ module.exports = (hermione, opts) => {
         if (!config.browsers.includes(browserId)) {
             return;
         }
+        async function reassertView(baseAssertViewFn, ...args) {
+            await baseAssertViewFn.apply(this, args);
 
-        const baseAssertView = browser.assertView.bind(browser);
-        browser.addCommand('assertView', async function(...args) {
-            await baseAssertView(...args);
+            const assertViewResults = browser.executionContext.hermioneCtx.assertViewResults.get();
 
-            const assertViewResults = this.executionContext.hermioneCtx.assertViewResults.get();
+            await reassertLastResult(assertViewResults, config, browser.executionContext.ctx.currentTest);
+        }
 
-            await reassertLastResult(assertViewResults, config, this.executionContext.ctx.currentTest);
-        }, true);
+        browser.overwriteCommand('assertView', reassertView);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "resemblejs": "^3.1.0"
   },
   "peerDependencies": {
-    "hermione": ">=4.0.0"
+    "hermione": ">=5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "debug": "^4.1.0",
     "gemini-configparser": "^1.0.0",
     "resemblejs": "^3.1.0"
+  },
+  "peerDependencies": {
+    "hermione": ">=4.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: drop support for hermione@3

Also, added support for future hermione's element.assertView